### PR TITLE
feat: expand sidebar for external links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,20 @@ To add a top-level sidebar section, place a sibling in a desired position inside
 
 :warning: Note, that it is not enough to define a page in a sidebar for it to appear! For each page there has to be a corresponding `.md` file used for page generation.
 
+To add an external link to the sidebar section, place it at the desired position within the top-level `external` array:
+
+```json
+{
+  "external": [
+    // your new item
+    {
+      "title": "An external link to app",
+      "slug": "https://app.configu.com"
+    }
+  ]
+}
+```
+⚠️  Note, that external links are not parts of docs internal navigation and won't be displayed at the bottom of a doc page. They live at the very end of the navigation sidebar, and the order can be adjusted only within `external` array.
 **Attributes breakdown**:
 
 - the `title` attribute is required and is a represenation of a certain `.md` page in sidebar. `title` may differ from the on inside the page

--- a/content/sidebar.json
+++ b/content/sidebar.json
@@ -157,7 +157,9 @@
           "slug": "hc-vault-w-configu"
         }
       ]
-    },
+    }
+  ],
+  "external": [
     {
       "title": "Contributing",
       "slug": "https://github.com/configu/configu/blob/main/CONTRIBUTING.md"

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -65,7 +65,7 @@ const createDocPages = async ({ graphql, actions }) => {
       component: `${docTemplate}?__contentFilePath=${contentFilePath}`,
       context: {
         id,
-        sidebar: sidebar.items,
+        sidebar,
         previousLink,
         nextLink,
         tableOfContents: tableOfContents?.items,

--- a/src/components/pages/doc/sidebar/item/item.jsx
+++ b/src/components/pages/doc/sidebar/item/item.jsx
@@ -14,11 +14,11 @@ const Item = ({ id, title, slug, items, isOpen, currentSlug, onKeyDown, onClick 
           'flex w-full items-center py-1.5 text-left font-mono text-sm font-semibold leading-snug text-grey-25 transition-colors duration-200 hover:text-blue-light dark:text-white dark:hover:text-blue-dark',
           {
             '!text-blue-light dark:!text-blue-dark': currentSlug === slug,
-            'external-link': slug.startsWith('http'),
           }
         )}
         to={slug.startsWith('http') ? slug : slugToHref(slug)}
         target={slug.startsWith('http') ? '_blank' : undefined}
+        isExternal={slug.startsWith('http')}
         theme="black"
       >
         {title}

--- a/src/components/pages/doc/sidebar/item/item.jsx
+++ b/src/components/pages/doc/sidebar/item/item.jsx
@@ -14,10 +14,11 @@ const Item = ({ id, title, slug, items, isOpen, currentSlug, onKeyDown, onClick 
           'flex w-full items-center py-1.5 text-left font-mono text-sm font-semibold leading-snug text-grey-25 transition-colors duration-200 hover:text-blue-light dark:text-white dark:hover:text-blue-dark',
           {
             '!text-blue-light dark:!text-blue-dark': currentSlug === slug,
+            'external-link': slug.startsWith('http'),
           }
         )}
-        to={slug.includes('http') ? slug : slugToHref(slug)}
-        target={slug.includes('http') ? '_blank' : undefined}
+        to={slug.startsWith('http') ? slug : slugToHref(slug)}
+        target={slug.startsWith('http') ? '_blank' : undefined}
         theme="black"
       >
         {title}

--- a/src/components/pages/doc/sidebar/sidebar.jsx
+++ b/src/components/pages/doc/sidebar/sidebar.jsx
@@ -8,10 +8,10 @@ import { useSidebarContext } from 'context/sidebar-context';
 import Item from './item';
 
 const Sidebar = ({ className, sidebar, currentSlug }) => {
-  const { sidebarOpenItems, setSidebarOpenItems, handleSidebarSectionState } = useSidebarContext();
+  const { sidebarOpenItems, handleSidebarSectionState } = useSidebarContext();
   const activePageItemIndex = useMemo(
     () =>
-      sidebar.findIndex(({ slug, items }) => {
+      sidebar.items.findIndex(({ slug, items }) => {
         if (slug) {
           return slug === currentSlug;
         }
@@ -27,9 +27,7 @@ const Sidebar = ({ className, sidebar, currentSlug }) => {
   );
 
   useEffect(() => {
-    if (JSON.stringify(sidebarOpenItems) === '{}') {
-      setSidebarOpenItems({ [activePageItemIndex]: true });
-    } else if (!(activePageItemIndex.toString() in sidebarOpenItems)) {
+    if (!sidebarOpenItems[activePageItemIndex]) {
       handleSidebarSectionState(activePageItemIndex);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -46,11 +44,21 @@ const Sidebar = ({ className, sidebar, currentSlug }) => {
       <Search className="md:hidden" additionalResultsStyles="max-h-[70vh]" />
       <nav className="mt-5 md:hidden">
         <ul>
-          {sidebar.map((item, index) => (
+          {sidebar.items.map((item, index) => (
             <Item
               {...item}
               id={index}
               isOpen={sidebarOpenItems[index]}
+              currentSlug={currentSlug}
+              key={index}
+              onClick={handleItemClick}
+              onKeyDown={handleItemClick}
+            />
+          ))}
+          {sidebar.external.map((item, index) => (
+            <Item
+              {...item}
+              id={index}
               currentSlug={currentSlug}
               key={index}
               onClick={handleItemClick}
@@ -62,11 +70,21 @@ const Sidebar = ({ className, sidebar, currentSlug }) => {
       <nav className="relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] hidden w-screen bg-grey-96 dark:bg-grey-25 md:block md:px-7 sm:px-4">
         <CollapsibleItem title="Docs navigation" type="navigation">
           <ul className="pt-3">
-            {sidebar.map((item, index) => (
+            {sidebar.items.map((item, index) => (
               <Item
                 {...item}
                 id={index}
                 isOpen={sidebarOpenItems[index]}
+                currentSlug={currentSlug}
+                key={index}
+                onClick={handleItemClick}
+                onKeyDown={handleItemClick}
+              />
+            ))}
+            {sidebar.external.map((item, index) => (
+              <Item
+                {...item}
+                id={index}
                 currentSlug={currentSlug}
                 key={index}
                 onClick={handleItemClick}
@@ -82,24 +100,44 @@ const Sidebar = ({ className, sidebar, currentSlug }) => {
 
 Sidebar.propTypes = {
   className: PropTypes.string,
-  sidebar: PropTypes.arrayOf(
-    PropTypes.exact({
-      title: PropTypes.string.isRequired,
-      slug: PropTypes.string,
-      items: PropTypes.arrayOf(
-        PropTypes.exact({
-          title: PropTypes.string.isRequired,
-          slug: PropTypes.string,
-          items: PropTypes.arrayOf(
-            PropTypes.exact({
-              title: PropTypes.string.isRequired,
-              slug: PropTypes.string.isRequired,
-            })
-          ),
-        })
-      ),
-    })
-  ).isRequired,
+  sidebar: PropTypes.exact({
+    items: PropTypes.arrayOf(
+      PropTypes.exact({
+        title: PropTypes.string.isRequired,
+        slug: PropTypes.string,
+        items: PropTypes.arrayOf(
+          PropTypes.exact({
+            title: PropTypes.string.isRequired,
+            slug: PropTypes.string,
+            items: PropTypes.arrayOf(
+              PropTypes.exact({
+                title: PropTypes.string.isRequired,
+                slug: PropTypes.string.isRequired,
+              })
+            ),
+          })
+        ),
+      })
+    ),
+    external: PropTypes.arrayOf(
+      PropTypes.exact({
+        title: PropTypes.string.isRequired,
+        slug: PropTypes.string,
+        items: PropTypes.arrayOf(
+          PropTypes.exact({
+            title: PropTypes.string.isRequired,
+            slug: PropTypes.string,
+            items: PropTypes.arrayOf(
+              PropTypes.exact({
+                title: PropTypes.string.isRequired,
+                slug: PropTypes.string.isRequired,
+              })
+            ),
+          })
+        ),
+      })
+    ),
+  }).isRequired,
   currentSlug: PropTypes.string.isRequired,
 };
 

--- a/src/components/pages/doc/sidebar/sidebar.jsx
+++ b/src/components/pages/doc/sidebar/sidebar.jsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import React, { useEffect, useMemo } from 'react';
 
@@ -40,7 +41,12 @@ const Sidebar = ({ className, sidebar, currentSlug }) => {
   };
 
   return (
-    <aside className={className}>
+    <aside
+      className={clsx(
+        'sticky top-9 my-9 h-full max-h-[calc(100vh-80px)] overflow-y-auto pr-5 md:relative md:top-auto md:my-0 md:max-h-full md:w-full md:overflow-y-visible md:pr-0',
+        className
+      )}
+    >
       <Search className="md:hidden" additionalResultsStyles="max-h-[70vh]" />
       <nav className="mt-5 md:hidden">
         <ul>

--- a/src/components/shared/link/link.jsx
+++ b/src/components/shared/link/link.jsx
@@ -7,6 +7,7 @@ import { getCookieConsentValue } from 'react-cookie-consent';
 
 import useSegmentEvent from 'hooks/use-segment-event';
 import Arrow from 'icons/arrow.inline.svg';
+import ExternalIcon from 'icons/external-link.inline.svg';
 
 const styles = {
   base: 'font-semibold inline-flex items-baseline leading-none transition-colors duration-200 group relative',
@@ -71,6 +72,7 @@ const Link = ({
   nav,
   children,
   isClickTracked,
+  isExternal,
   ...props
 }) => {
   const isCookieAccepted = useMemo(() => getCookieConsentValue() === 'true', []);
@@ -171,12 +173,19 @@ const Link = ({
       {...props}
     >
       {nav === 'prev' && (
-        <Arrow className="mr-2 h-[10px] w-[16px] rotate-180 fill-blue-light transition-[fill] duration-200 group-hover:fill-blue-light-hover dark:fill-blue-dark dark:group-hover:fill-blue-light" />
+        <Arrow
+          className="mr-2 h-[10px] w-[16px] rotate-180 fill-blue-light transition-[fill] duration-200 group-hover:fill-blue-light-hover dark:fill-blue-dark dark:group-hover:fill-blue-light"
+          aria-hidden
+        />
       )}
       {children}
       {nav === 'next' && (
-        <Arrow className="ml-2 h-[10px] w-[16px] fill-blue-light transition-[fill] duration-200 group-hover:fill-blue-light-hover dark:fill-blue-dark dark:group-hover:fill-blue-light" />
+        <Arrow
+          className="ml-2 h-[10px] w-[16px] fill-blue-light transition-[fill] duration-200 group-hover:fill-blue-light-hover dark:fill-blue-dark dark:group-hover:fill-blue-light"
+          aria-hidden
+        />
       )}
+      {isExternal && <ExternalIcon className="ml-1 h-3.5 w-3.5" aria-hidden />}
       {isUnderline && underline}
     </a>
   );
@@ -190,6 +199,7 @@ Link.propTypes = {
   children: PropTypes.node.isRequired,
   nav: PropTypes.oneOf(['prev', 'next']),
   isClickTracked: PropTypes.bool,
+  isExternal: PropTypes.bool,
 };
 
 Link.defaultProps = {
@@ -199,6 +209,7 @@ Link.defaultProps = {
   theme: 'black',
   nav: null,
   isClickTracked: false,
+  isExternal: false,
 };
 
 export default Link;

--- a/src/context/sidebar-context.jsx
+++ b/src/context/sidebar-context.jsx
@@ -1,10 +1,17 @@
 import React, { useMemo, createContext, useContext, useState, useCallback } from 'react';
 
+import sidebar from '../../content/sidebar.json';
+
 export const SidebarContext = createContext([]);
 
 // eslint-disable-next-line react/prop-types
 export const SidebarContextAPI = ({ children }) => {
-  const [sidebarOpenItems, setSidebarOpenItems] = useState({});
+  const [sidebarOpenItems, setSidebarOpenItems] = useState(
+    sidebar.items.reduce((acc, _, i) => {
+      acc[i] = true;
+      return acc;
+    }, {})
+  );
 
   const handleSidebarSectionState = useCallback(
     (id) => {

--- a/src/icons/external-link.inline.svg
+++ b/src/icons/external-link.inline.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="none"><path stroke="currentColor" stroke-linecap="square" stroke-width="1.6" d="M12.001 8.667V14h-10L2 4h5.334M10 2h4v4M6.668 9.333l6.787-6.788"/></svg>

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -208,10 +208,6 @@
       @apply border-grey-40;
     }
 
-    .external-link {
-      @apply relative after:ml-1 after:inline-block after:h-[14px] after:w-[14px] after:bg-external-icon-light after:bg-contain after:align-baseline after:text-blue-light after:transition-all after:duration-200 hover:after:bg-external-icon-light-hover dark:after:bg-external-icon-dark dark:hover:after:bg-external-icon-light;
-    }
-
     .gatsby-resp-image-wrapper {
       margin-top: 1.25em;
       margin-bottom: 1.25em;
@@ -268,6 +264,10 @@
         @apply text-black dark:text-white;
       }
     }
+  }
+
+  .external-link {
+    @apply relative after:ml-1 after:inline-block after:h-[14px] after:w-[14px] after:bg-external-icon-light after:bg-contain after:align-baseline after:text-blue-light after:transition-all after:duration-200 hover:after:bg-external-icon-light-hover dark:after:bg-external-icon-dark dark:hover:after:bg-external-icon-light;
   }
 
   .admonition p {

--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -26,7 +26,7 @@ const DocTemplate = (props) => {
       <div className="border-b border-t border-grey-88 dark:border-grey-40 md:border-t-0 md:border-b-0">
         <div className="container grid w-full grid-cols-[300px_1fr_300px] px-0 xl:px-10 lg:grid-cols-[300px_1fr] md:flex md:flex-col md:px-7 sm:px-4">
           <Sidebar
-            className="pt-9 pr-5 md:w-full md:pr-0 md:pt-0"
+            className="py-9 pr-5 md:w-full md:py-0 md:pr-0"
             sidebar={sidebar}
             currentSlug={frontmatter.slug}
           />

--- a/src/templates/doc.jsx
+++ b/src/templates/doc.jsx
@@ -25,11 +25,7 @@ const DocTemplate = (props) => {
     <Layout>
       <div className="border-b border-t border-grey-88 dark:border-grey-40 md:border-t-0 md:border-b-0">
         <div className="container grid w-full grid-cols-[300px_1fr_300px] px-0 xl:px-10 lg:grid-cols-[300px_1fr] md:flex md:flex-col md:px-7 sm:px-4">
-          <Sidebar
-            className="py-9 pr-5 md:w-full md:py-0 md:pr-0"
-            sidebar={sidebar}
-            currentSlug={frontmatter.slug}
-          />
+          <Sidebar sidebar={sidebar} currentSlug={frontmatter.slug} />
 
           <div className="overflow-hidden border-l border-r border-grey-88 px-9 pb-20 pt-7 dark:border-grey-40 lg:border-r-0 lg:pr-0 md:border-l-0 md:pl-0">
             <Content


### PR DESCRIPTION
This PR brings the changes to add external links to the sidebar and make the sidebar always open by default.
https://configudocs-sidebarnavigation.gatsbyjs.io/docs/