### PR TITLE
docs(): added stores and cfgu-types

### DIFF
--- a/content/Concepts/cfgu.mdx
+++ b/content/Concepts/cfgu.mdx
@@ -35,9 +35,12 @@ Configu supports the following types for configuration values:
 - **SemVer**: Represents a semantic version number. Example: `1.2.3-4`
 - **IPv4**: Represents an IPv4 address. Example: `127.0.0.1`
 - **IPv6**: Represents an IPv6 address. Example: `2600:4040:b5c4:1100:216:3eff:feda:953b`
+- **MACAddress**: Represents a MAC Address. Example: `4g:54:53:2f:f6:28`
 - **Domain**: Represents a domain name. Example: `example.com`
 - **URL**: Represents a URL. Example: `https://www.example.com`
+- **MIMEType**: Represents a MIME type. Example: `application/octet-stream`
 - **ConnectionString**: Represents a connection string. Example: `Server=example.com;Database=myDB;User Id=myUser;Password=myPass;`
+- **DockerImage**: Represents a docker image tag name. Example: `debian:stable-20230814-slim`
 - **Hex**: Represents a value encoded in hexadecimal format. Example: A Hex Encoded Value
 - **Base64**: Represents a value encoded in Base64 format. Example: A Base64 Encoded Value
 - **MD5**: Represents a value hashed using MD5. Example: A MD5 Hashed Value
@@ -48,11 +51,15 @@ Configu supports the following types for configuration values:
 - **Locale**: Represents a specific language and region combination. Example: `EN-GB`
 - **LatLong**: Represents latitude and longitude coordinates. Example: `41 24.2028, 2 10.4418`
 - **Country**: Represents a country code. Example: `GB`
-  {/* - **Language**: Represents a language code. Example: `en`, `he` */}
+- **Language**: Represents a language code. Example: `en`, `he`
 - **Currency**: Represents a currency code. Example: `USD`
-  {/* - **AWSRegion**: Represents an AWS region. Example: `eu-west-1`, `us-west-2` */}
-  {/* - **AzureRegion**: Represents an Azure region. Example: `brazilsouth`, `australiaeast` */}
-  {/* - **GCPRegion**: Represents a GCP region. Example: `asia-south1`, `asia-southeast2` */}
+- **CreditCard**: Represents a credit card number. Example: `374245455400126`
+- **AWSRegion**: Represents an AWS region. Example: `eu-west-1`, `us-west-2`
+- **AZRegion**: Represents an Azure region. Example: `brazilsouth`, `australiaeast`
+- **GCPRegion**: Represents a GCP region. Example: `asia-south1`, `asia-southeast2`
+- **OracleRegion**: Represents a Oracle Cloud region. Example: `us-ashburn-1`
+- **IBMRegion**: Represents a IBM Cloud region. Example: `us-south`, `sa-santiago`
+- **AlibabaRegion**: Represents a Alibaba Cloud region. Example: `cn-hangzhou`
 
 <Admonition type="tip">
 

--- a/content/Concepts/cfgu.mdx
+++ b/content/Concepts/cfgu.mdx
@@ -53,7 +53,6 @@ Configu supports the following types for configuration values:
 - **Country**: Represents a country code. Example: `GB`
 - **Language**: Represents a language code. Example: `en`, `he`
 - **Currency**: Represents a currency code. Example: `USD`
-- **CreditCard**: Represents a credit card number. Example: `374245455400126`
 - **AWSRegion**: Represents an AWS region. Example: `eu-west-1`, `us-west-2`
 - **AZRegion**: Represents an Azure region. Example: `brazilsouth`, `australiaeast`
 - **GCPRegion**: Represents a GCP region. Example: `asia-south1`, `asia-southeast2`

--- a/content/Concepts/config-store.mdx
+++ b/content/Concepts/config-store.mdx
@@ -47,6 +47,33 @@ You can choose the appropriate `ConfigStore` based on your specific use case, an
 />
 
 <StoreInfo
+  category="key value"
+  name="AWS Parameter Store"
+  type="aws-parameter-store"
+  interfaces={['CLI', 'Node.js']}
+  docs="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ssm/"
+  configs="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-ssm/Interface/SSMClientConfig/"
+/>
+
+<StoreInfo
+  category="key value"
+  name="Keyv"
+  type="keyv"
+  interfaces={['CLI', 'Node.js']}
+  docs="https://github.com/jaredwray/keyv"
+  configs="https://github.com/jaredwray/keyv"
+/>
+
+<StoreInfo
+  category="feature flag"
+  name="Launch Darkly"
+  type="launch-darkly"
+  interfaces={['CLI', 'Node.js']}
+  docs="https://apidocs.launchdarkly.com/tag/Feature-flags"
+  configs="https://github.com/launchdarkly-labs/ldc"
+/>
+
+<StoreInfo
   category="secret manager"
   name="HashiCorp Vault"
   type="hashicorp-vault"

--- a/content/Concepts/config-store.mdx
+++ b/content/Concepts/config-store.mdx
@@ -47,24 +47,6 @@ You can choose the appropriate `ConfigStore` based on your specific use case, an
 />
 
 <StoreInfo
-  category="key value"
-  name="AWS Parameter Store"
-  type="aws-parameter-store"
-  interfaces={['CLI', 'Node.js']}
-  docs="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ssm/"
-  configs="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-ssm/Interface/SSMClientConfig/"
-/>
-
-<StoreInfo
-  category="key value"
-  name="Keyv"
-  type="keyv"
-  interfaces={['CLI', 'Node.js']}
-  docs="https://github.com/jaredwray/keyv"
-  configs="https://github.com/jaredwray/keyv"
-/>
-
-<StoreInfo
   category="feature flag"
   name="Launch Darkly"
   type="launch-darkly"
@@ -116,6 +98,24 @@ You can choose the appropriate `ConfigStore` based on your specific use case, an
   interfaces={['CLI', 'Node.js', 'Python']}
   docs="https://kubernetes.io/docs/concepts/configuration/secret/"
   configs="https://github.com/kubernetes-client/javascript"
+/>
+
+<StoreInfo
+  category="key value"
+  name="AWS Parameter Store"
+  type="aws-parameter-store"
+  interfaces={['CLI', 'Node.js']}
+  docs="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ssm/"
+  configs="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-ssm/Interface/SSMClientConfig/"
+/>
+
+<StoreInfo
+  category="key value"
+  name="Keyv"
+  type="keyv"
+  interfaces={['CLI', 'Node.js']}
+  docs="https://github.com/jaredwray/keyv"
+  configs="https://github.com/jaredwray/keyv"
 />
 
 <StoreInfo

--- a/content/SDK/python-sdk.mdx
+++ b/content/SDK/python-sdk.mdx
@@ -24,23 +24,21 @@ config_store = configu.InMemoryConfigStore()
 test_set = configu.ConfigSet("test")
 schema = configu.ConfigSchema("get-started.cfgu.json")
 
-configu.UpsertCommand({
-    "store": config_store,
-    "set": test_set,
-    "schema": schema,
-    "configs": {
-        'GREETING': 'hey',
-        'SUBJECT': 'configu python sdk'
-    },
-}).run()
+configu.UpsertCommand(
+  store=config_store,
+  set=test_set,
+  schema=schema,
+  configs={
+    "GREETING": "hello",
+    "SUBJECT": "configu python sdk",
+  },
+).run()
 
-data = configu.EvalCommand({
-    "store": config_store,
-    "set": test_set,
-    "schema": schema,
-}).run()
+data = configu.EvalCommand(
+  store=config_store, set=test_set, schema=schema
+).run()
 
-configuration_data = configu.ExportCommand({"data": data}).run()
+configuration_data = configu.ExportCommand(data=data).run()
 
 print(os.environ["MESSAGE"])
 # hey, configu python sdk!


### PR DESCRIPTION
- Stores:
   - `aws-parameter-store`
   - `keyv`
   - `launch-darkly`
- Cfgu Types:
   - `MACAddress`
   - `MIMEType`
   - `DockerImage`
   - `Language`
   - `CreditCard`
   - `AWSRegion`
   - `AZRegion`
   - `GCPRegion`
   - `OracleRegion`
   - `IBMRegion`
   - `AlibabaRegion`