### PR TITLE
Add INI file to config store docs in Available Store

### DIFF
--- a/content/Concepts/config-store.mdx
+++ b/content/Concepts/config-store.mdx
@@ -47,6 +47,15 @@ You can choose the appropriate `ConfigStore` based on your specific use case, an
 />
 
 <StoreInfo
+  category="file"
+  name="Ini File"
+  type="ini-file"
+  interfaces={['Node.js']}
+  docs="https://configu.com/docs/"
+  configs="https://configu.com/docs/"
+/>
+
+<StoreInfo
   category="feature flag"
   name="Launch Darkly"
   type="launch-darkly"


### PR DESCRIPTION
Here's the example to use it for future detailed Docs:

```typescript
const path = require('path');

const {
  IniFileConfigStore
} =  require('@configu/node');

const inipath = path.join(__dirname, 'config.ini');
const configStore = new IniFileConfigStore({
    path: inipath
});

configStore.read().then(configs => {
    console.log(JSON.stringify(configs, null, 2));
    configs.push({
        set: 'new_section',
        key: 'new_key',
        value: 'new_value'
    })
    configStore.write(configs).then(() => {
        console.log('write success')
    }
    ).catch((err) => {
        console.log(err)
    });
});
```
Here's the sample INI file output of above code:

```ini
global_key1=value1
global_key2=value2

[Basic]
Name=John Doe
Age=30
Country=USA

[KeysWithSpaces]
full name=John Doe
postal code=12345

[SpecialCharacters]
email=john.doe@example.com
website=http://www.example.com

[NumericValues]
integer=10
float=10.5

[QuotedValues]
sentence="This is a quoted sentence."

[EscapeSequences]
path=C:\Program Files\App
newline=This is a text\nwith a newline.

[Miscellaneous]
empty_key=

[new_section]
new_key=new_value
```