### PR TITLE
Fix broken link in integrations page

### DIFF
--- a/content/Platform/integrations.mdx
+++ b/content/Platform/integrations.mdx
@@ -8,7 +8,7 @@ title: Integrations
 
 Configu lets you to connect your GitHub repositories to your organization. Connecting your repositories enables the following features:
 
-- Share access to ConfigSchema files directly from your repositories with your entire organization and streamline config management via the [Config Editor](../configs/#configs-editor).
+- Share access to ConfigSchema files directly from your repositories with your entire organization and streamline config management via the [Config Editor](../configs-editor).
 - Validate your ConfigSchema when you open pull requests.
 
 To connect your GitHub repositories:


### PR DESCRIPTION
I have fixed the broken link in the Integrations page in Configu's Docs.
Fixes #57 