### PR TITLE
chore: remove npm move command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "start": "npm run develop",
     "develop": "gatsby develop -H 0.0.0.0",
     "build": "gatsby build --prefix-paths",
-    "move": "cd public && mkdir docs | mv * docs",
     "serve": "gatsby serve --prefix-paths",
     "clean": "gatsby clean",
     "format": "prettier --write --ignore-path .gitignore .",


### PR DESCRIPTION
This PR removes npm `move` command